### PR TITLE
feat: Add support for backing up and restoring schema DDL.

### DIFF
--- a/src/databudgie/adapter/base.py
+++ b/src/databudgie/adapter/base.py
@@ -20,6 +20,11 @@ class Adapter(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
+    def export_schema_ddl(session: Session, name: str):
+        raise NotImplementedError()  # pragma: no cover
+
+    @staticmethod
+    @abc.abstractmethod
     def export_table_ddl(session: Session, table_name: str):
         raise NotImplementedError()  # pragma: no cover
 

--- a/src/databudgie/adapter/fallback.py
+++ b/src/databudgie/adapter/fallback.py
@@ -64,6 +64,10 @@ class PythonAdapter(Adapter):
             yield row
 
     @staticmethod
+    def export_schema_ddl(session: Session, name: str) -> bytes:
+        raise NotImplementedError()
+
+    @staticmethod
     def export_table_ddl(session: Session, table_name: str):
         raise NotImplementedError()
 

--- a/src/databudgie/etl/base.py
+++ b/src/databudgie/etl/base.py
@@ -7,6 +7,21 @@ from sqlalchemy import inspect
 from databudgie.config import normalize_table_config, TableConf
 from databudgie.manifest.manager import Manifest
 from databudgie.match import collect_existing_tables, expand_table_globs
+from databudgie.utils import parse_table
+
+
+@dataclass
+class SchemaOp:
+    name: str
+    raw_conf: TableConf
+
+    @classmethod
+    def from_table_op(cls, table_op: "TableOp") -> "SchemaOp":
+        schema, _ = parse_table(table_op.table_name)
+        return cls(schema, table_op.raw_conf)
+
+    def location(self, ref) -> str:
+        return self.raw_conf["location"].format(table=self.name, ref=ref)
 
 
 @dataclass
@@ -31,6 +46,9 @@ class TableOp:
             return None
 
         return query.format(table=self.table_name, ref=ref)
+
+    def schema_op(self) -> SchemaOp:
+        return SchemaOp.from_table_op(self)
 
 
 def expand_table_ops(

--- a/src/databudgie/match.py
+++ b/src/databudgie/match.py
@@ -1,4 +1,5 @@
 import fnmatch
+import warnings
 from typing import Iterable
 
 from sqlalchemy import inspect, MetaData
@@ -33,6 +34,9 @@ def collect_existing_tables(session: Session):
         # Seems to be a generally cross-database compatible filter.
         if schema == "information_schema":
             continue
-        metadata.reflect(bind=connection, schema=schema)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            metadata.reflect(bind=connection, schema=schema)
 
     return [table.fullname for table in metadata.sorted_tables]

--- a/tests/databudgie/test_restore.py
+++ b/tests/databudgie/test_restore.py
@@ -299,7 +299,7 @@ def test_compression(pg, s3_resource, config):
     """Validate restore functionality with compression enabled."""
     mock_store = dict(id=1, name=fake.name())
 
-    mock_s3_csv(s3_resource, "public.store/2021-04-26T09:00:00.csv", [mock_store], gzipped=True)
+    mock_s3_csv(s3_resource, "public.store/2021-04-26T09:00:00.csv.gz", [mock_store], gzipped=True)
 
     config = make_config(restore=config)
     restore_all(pg, config, strict=True)


### PR DESCRIPTION
Currently the backup and restoration of schemas are dependent on there being tables selected for, which depend on it. That seems okay for now to me. Perhaps they should be specified at the DDL level though.

Current behavior implemented for postgres does a pg_dump that runs for a schema and excludes all tables in the schema. That ensures we get the schema creation statement, and permissioning, and (apparently importantly) types created on that schema (like enums).

If we can eventually better control this, we probably should. A pure-sqlalchemy fallback would **definitely** end up creating those types with the table's backup and then end up with decidedly different semantics.

Future changes to backup semantics **should** largely be invisible though, so it feels pretty safe to worry about that later, since we need this functionality now to perform full restores. if it works today it should be backwards compatible if we change the contents of individual backups, so long as the restore functionality is largely just executing sql blocks (which it is)