### PR TITLE
chore: Default to fast native table collection.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databudgie"
-version = "2.5.2"
+version = "2.6.0"
 description = ""
 authors = ["Andrew Sosa <andrewso@known.is>", "Dan Cardin <ddcardin@gmail.com>"]
 packages = [

--- a/src/databudgie/adapter/postgres.py
+++ b/src/databudgie/adapter/postgres.py
@@ -97,8 +97,8 @@ class PostgresAdapter(Adapter):
     def collect_existing_tables(session: Session) -> List[str]:
         """Find the set of all user-defined tables in a database."""
 
-        if "ENABLE_EXPERIMENTAL_TABLE_COLLECTION" not in os.environ:
-            log.info("Set ENABLE_EXPERIMENTAL_TABLE_COLLECTION to use faster experimental table collection.")
+        if "FALLBACK_SQLALCHEMY_TABLE_COLLECTION" in os.environ:
+            log.info("Using SQLAlchemy to collect tables.")
             return Adapter.collect_existing_tables(session)
 
         # from https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres


### PR DESCRIPTION
The current table collection query at least works in most common cases that we've seen. IF we find a future case where it doesnt work, then we could always use the current query as a base to implement a legitimate kahn's algorithm against it in python

tl;dr i want it to be fast without remembering to have the flag in my env.