### PR TITLE
refactor: adapter and strict flags into config.

### DIFF
--- a/src/databudgie/cli/commands.py
+++ b/src/databudgie/cli/commands.py
@@ -55,6 +55,8 @@ def cli(
         tables=list(table) if table else None,
         url=url,
         location=location,
+        adapter=adapter,
+        strict=strict,
     )
 
     configs = load_configs(config)
@@ -66,9 +68,7 @@ def cli(
         raise click.UsageError(*e.args)
 
     resolver.register_values(
-        adapter=adapter,
         root_config=root_config,
-        strict=strict,
         verbosity=verbose,
         console=Console(verbosity=verbose),
     )
@@ -79,10 +79,8 @@ def cli(
 def backup_cli(
     backup_config: BackupConfig,
     backup_db: Session,
-    strict: bool,
     console: Console,
     verbosity: int = 0,
-    adapter: Optional[str] = None,
     backup_manifest: Optional[Manifest] = None,
     backup_id: Optional[int] = None,
 ):
@@ -90,15 +88,13 @@ def backup_cli(
     from databudgie.cli.setup import setup
     from databudgie.etl.backup import backup_all
 
-    setup(backup_config.sentry, backup_config.logging, verbosity=verbosity)
+    setup(backup_config.sentry)
 
     if backup_manifest and backup_id:
         backup_manifest.set_transaction_id(backup_id)
 
     try:
-        backup_all(
-            backup_db, backup_config, manifest=backup_manifest, strict=strict, adapter_name=adapter, console=console
-        )
+        backup_all(backup_db, backup_config, manifest=backup_manifest, console=console)
     except Exception as e:
         console.trace(e)
         raise click.ClickException(*e.args)
@@ -122,12 +118,10 @@ def backup_cli(
 def restore_cli(
     restore_config: RestoreConfig,
     restore_db: Session,
-    strict: bool,
     verbosity: int,
     console: Console,
     restore_manifest: Optional[Manifest] = None,
     restore_id: Optional[int] = None,
-    adapter: Optional[str] = None,
     clean: Optional[bool] = None,
     yes: bool = False,
 ):
@@ -135,7 +129,7 @@ def restore_cli(
     from databudgie.cli.setup import setup
     from databudgie.etl.restore import restore_all
 
-    setup(restore_config.sentry, restore_config.logging, verbosity=verbosity)
+    setup(restore_config.sentry)
 
     if restore_manifest and restore_id:
         restore_manifest.set_transaction_id(restore_id)
@@ -148,14 +142,7 @@ def restore_cli(
             return False
 
     try:
-        restore_all(
-            restore_db,
-            restore_config=restore_config,
-            manifest=restore_manifest,
-            strict=strict,
-            adapter_name=adapter,
-            console=console,
-        )
+        restore_all(restore_db, restore_config=restore_config, manifest=restore_manifest, console=console)
     except Exception as e:
         console.trace(e)
         raise click.ClickException(*e.args)

--- a/src/databudgie/cli/config.py
+++ b/src/databudgie/cli/config.py
@@ -21,6 +21,8 @@ class CliConfig(models.Config):
     ddl: Optional[bool] = None
     url: Optional[str] = None
     location: Optional[str] = None
+    adapter: Optional[str] = None
+    strict: Optional[bool] = None
 
     def to_dict(self) -> dict:
         config = asdict(self)

--- a/src/databudgie/cli/setup.py
+++ b/src/databudgie/cli/setup.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import strapp.logging
 
-from databudgie.config.models import LoggingConfig, SentryConfig
+from databudgie.config.models import SentryConfig
 
 package_verbosity = strapp.logging.package_verbosity_factory(
     ("urllib3", logging.INFO, logging.INFO, logging.INFO, logging.DEBUG),
@@ -17,10 +17,7 @@ package_verbosity = strapp.logging.package_verbosity_factory(
 )
 
 
-def setup(sentry: Optional[SentryConfig], logging: Optional[LoggingConfig], verbosity: int):
-    if logging:
-        setup_logging(logging.level, verbosity)
-
+def setup(sentry: Optional[SentryConfig]):
     if sentry:
         setup_sentry(sentry)
 
@@ -35,25 +32,4 @@ def setup_sentry(config: SentryConfig):
         service_name="databudgie",
         level="WARNING",
         breadcrumb_level="INFO",
-    )
-
-
-def setup_logging(level: str, verbosity: int):
-    from setuplog import setup_logging as _setup_logging
-
-    level_map = {
-        "30": logging.WARNING,
-        "WARNING": logging.WARNING,
-        "20": logging.INFO,
-        "INFO": logging.INFO,
-        "10": logging.DEBUG,
-        "DEBUG": logging.DEBUG,
-    }
-
-    chosen_level = level_map.get(level.upper(), logging.INFO)
-    actual_level = max(chosen_level - 10 * verbosity, logging.DEBUG)
-
-    _setup_logging(
-        actual_level,
-        log_level_overrides=package_verbosity(verbosity),
     )

--- a/src/databudgie/etl/restore.py
+++ b/src/databudgie/etl/restore.py
@@ -29,11 +29,9 @@ def restore_all(
     restore_config: RestoreConfig,
     console: Console = default_console,
     manifest: Optional[Manifest] = None,
-    adapter_name: Optional[str] = None,
-    strict=False,
 ) -> None:
     """Perform restore on all tables in the config."""
-    adapter = Adapter.get_adapter(session, adapter_name)
+    adapter = Adapter.get_adapter(session, restore_config.adapter)
     s3_resource = optional_s3_resource(restore_config)
 
     if restore_config.ddl.clean:
@@ -84,7 +82,6 @@ def restore_all(
         manifest=manifest,
         adapter=adapter,
         s3_resource=s3_resource,
-        strict=strict,
         console=console,
     )
 
@@ -233,7 +230,6 @@ def restore_tables(
     session: Session,
     table_ops: Sequence[TableOp],
     *,
-    strict=False,
     adapter: Adapter,
     console: Console = default_console,
     manifest: Optional[Manifest] = None,
@@ -248,7 +244,7 @@ def restore_tables(
 
             progress.update(task, description=f"Restoring table: {table_op.full_name}")
 
-            with capture_failures(strict=strict):
+            with capture_failures(strict=table_op.raw_conf.strict):
                 restore(
                     session,
                     table_op=table_op,

--- a/tests/databudgie/ddl/config.backup.yml
+++ b/tests/databudgie/ddl/config.backup.yml
@@ -1,3 +1,4 @@
+strict: true
 backup:
   ddl:
     enabled: <% ENV[DDL_ENABLED, true] %>

--- a/tests/databudgie/ddl/config.restore.yml
+++ b/tests/databudgie/ddl/config.restore.yml
@@ -1,3 +1,4 @@
+strict: true
 restore:
   ddl:
     enabled: <% ENV[DDL_ENABLED, true] %>

--- a/tests/databudgie/ddl/test_ddl.py
+++ b/tests/databudgie/ddl/test_ddl.py
@@ -38,7 +38,7 @@ def test_backup_ddl_disabled(pg):
             config = Config.from_yaml(folder / "config.backup.yml")
             config = RootConfig.from_dict(config.to_dict())
 
-        backup_all(pg, config.backup, strict=True)
+        backup_all(pg, config.backup)
 
         assert not os.path.exists(os.path.join(temp_dir, "ddl"))
 
@@ -51,7 +51,7 @@ def test_backup_ddl(pg, dir=None):
             config = Config.from_yaml(folder / "config.backup.yml")
             config = RootConfig.from_dict(config.to_dict())
 
-        backup_all(pg, config.backup, strict=True)
+        backup_all(pg, config.backup)
 
         assert os.path.exists(os.path.join(temp_dir, "ddl"))
 
@@ -67,7 +67,7 @@ def test_restore_ddl(pg, empty_db, mf):
             config = Config.from_yaml(folder / "config.restore.yml")
             config = RootConfig.from_dict(config.to_dict())
 
-        restore_all(empty_db, config.restore, strict=True)
+        restore_all(empty_db, config.restore)
         empty_db.commit()
 
         rows = empty_db.query(Store).all()
@@ -85,7 +85,7 @@ def test_restore_ddl_disabled(pg, empty_db, mf):
             config = Config.from_yaml(folder / "config.restore.yml")
             config = RootConfig.from_dict(config.to_dict())
 
-        restore_all(empty_db, config.restore, strict=True)
+        restore_all(empty_db, config.restore)
 
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as e:
             empty_db.query(Store).all()

--- a/tests/databudgie/test_follow_foreign_keys.py
+++ b/tests/databudgie/test_follow_foreign_keys.py
@@ -65,11 +65,12 @@ def test_backup_follow_foreign_keys(pg, s3_resource):
             "follow_foreign_keys": True,
             "sequences": False,
             "root_location": "s3://sample-bucket/",
+            "strict": True,
             **s3_config,
         }
     )
 
-    backup_all(pg, config.backup, strict=True)
+    backup_all(pg, config.backup)
 
     all_object_keys = [obj.key for obj in s3_resource.Bucket("sample-bucket").objects.all()]
     assert all_object_keys == [
@@ -102,12 +103,16 @@ def test_restore_follow_foreign_keys(pg, s3_resource):
             "follow_foreign_keys": True,
             "sequences": False,
             "clean": True,
+            "strict": True,
             "root_location": "s3://sample-bucket/",
             **s3_config,
         }
     )
 
-    restore_all(pg, config.restore, strict=True)
+    restore_all(
+        pg,
+        config.restore,
+    )
 
     assert pg.query(Store).one().id == 1
     assert pg.query(Product).one().id == 2

--- a/tests/databudgie/test_sequences.py
+++ b/tests/databudgie/test_sequences.py
@@ -32,10 +32,11 @@ def test_backup_without_sequences(pg, s3_resource):
             **table_config,
             **s3_config,
             "sequences": False,
+            "strict": True,
         }
     )
 
-    backup_all(pg, config.backup, strict=True)
+    backup_all(pg, config.backup)
 
     all_objects = [obj for obj in s3_resource.Bucket("sample-bucket").objects.all()]
     assert len(all_objects) == 1
@@ -50,6 +51,7 @@ def test_backup_with_sequences(pg, s3_resource, sequence_config, mf):
             **table_config,
             **s3_config,
             **sequence_config,
+            "strict": True,
         }
     )
 
@@ -57,7 +59,7 @@ def test_backup_with_sequences(pg, s3_resource, sequence_config, mf):
     mf.product.new()
     mf.product.new()
 
-    backup_all(pg, config.backup, strict=True)
+    backup_all(pg, config.backup)
 
     all_objects = [obj for obj in s3_resource.Bucket("sample-bucket").objects.all()]
     assert len(all_objects) == 2
@@ -76,12 +78,13 @@ def test_restore_without_sequences(pg, s3_resource):
             **table_config,
             **s3_config,
             "sequences": False,
+            "strict": True,
         }
     )
 
     mock_s3_json(s3_resource, "public.product/sequences/2021-04-26T09:00:00.json", {"product_id_seq": 91})
 
-    restore_all(pg, config.restore, strict=True)
+    restore_all(pg, config.restore)
 
     sequence_value = pg.execute(text("SELECT LAST_VALUE from product_id_seq")).scalar()
     assert sequence_value == 1
@@ -95,12 +98,13 @@ def test_restore_with_sequences(pg, s3_resource, sequence_config, mf):
             **table_config,
             **s3_config,
             **sequence_config,
+            "strict": True,
         }
     )
 
     mock_s3_json(s3_resource, "public.product/sequences/2021-04-26T09:00:00.json", {"product_id_seq": 91})
 
-    restore_all(pg, config.restore, strict=True)
+    restore_all(pg, config.restore)
 
     sequence_value = pg.execute(text("SELECT LAST_VALUE from product_id_seq")).scalar()
     assert sequence_value == 91


### PR DESCRIPTION
* Normalize adapter and strict flags as typical config options and route cli arguments through them. Largely this just makes more things work the same and reduces the number of kwargs being sent through the backup/restore commands
* remove logging config and logging setup. Everything uses `rich` now, so this doesn't do anything.