### PR TITLE
 feat: Add skip_if_exists per-table option for backups. 

### DIFF
--- a/docs/source/config/backup_restore.md
+++ b/docs/source/config/backup_restore.md
@@ -37,29 +37,43 @@ restore:
 
 ## `url` / `connection`
 
-The field name can be **either** of `url` or `connection`. Either this field
-must be supplied in the configuration, or the `connections` field (described in
-the next section) must be supplied.
+Examples below use `url` or `connection` depending on which makes more sense in
+the scenario. In reality, these options are exactly equivalent.
 
-This field value can be given either by a `RFC-1738` compliant string, or by the
-component parts of that string:
+The field name can be **any** of:
 
-```yaml
-# This
-url: dialect+driver://username:password@host:port/database
+- A "url": `RFC-1738` style connection string (directly routed to SQLAlchemy),
+  or its component parts:
 
-# Is the same as this:
-url:
-  drivername: dialect+driver
-  username: username
-  password: password
-  host: host
-  port: port
-  database: database
+  ```yaml
+  url: dialect+driver://username:password@host:port/database
+  ```
 
-# And either option can be given as:
-connection: ...
-```
+- An inline "connection", broken out by the above url's component parts:
+
+  ```yaml
+  connection:
+    drivername: dialect+driver
+    username: username
+    password: password
+    host: host
+    port: port
+    database: database
+  ```
+
+- A connection's name:
+
+  ```yaml
+  connections:
+    foo: dialect+driver://username:password@host:port/database
+    bar:
+      host: host
+      # ...
+
+  connection: foo
+  # or
+  connection: bar
+  ```
 
 ## `connections`
 

--- a/docs/source/config/table.md
+++ b/docs/source/config/table.md
@@ -8,9 +8,8 @@ backup:
     - name: foo # <--- here
 ```
 
-Remember that any option defined below can be specified at more general
-levels of config as a fallback for options which are the same across many/all
-tables.
+Remember that any option defined below can be specified at more general levels
+of config as a fallback for options which are the same across many/all tables.
 
 All options are intentionally identical, and in most cases are valid for both
 `backup` and `restore` commands, unless specifically noted otherwise.
@@ -20,9 +19,10 @@ All options are intentionally identical, and in most cases are valid for both
 When `tables` are given as a mapping, defaults to the key-side of the mapping.
 When `tables` are given as a list, this field is **required**!
 
-The `name` field defines the matching criteria for tables which should be backed up/
-restored. For the simplest case, this can just be the name (or `{schema}.{name}`)
-of the table. However this name can also be "globbed" to match multiple tables!
+The `name` field defines the matching criteria for tables which should be backed
+up/ restored. For the simplest case, this can just be the name (or
+`{schema}.{name}`) of the table. However this name can also be "globbed" to
+match multiple tables!
 
 ```{note}
 Remember each item in this list has a corresponding `query` field which can be
@@ -83,23 +83,24 @@ protocol to use for the backup/restore of that path.
 
 ### Local files
 
-Note an otherwise unadorned path will be assumed to be a local file path, for example
-`path/to/folder`.
+Note an otherwise unadorned path will be assumed to be a local file path, for
+example `path/to/folder`.
 
-For backups, if the path leading up to the leaf folder does not yet exist,
-it will be automatically created.
+For backups, if the path leading up to the leaf folder does not yet exist, it
+will be automatically created.
 
 ### S3
 
-A path is identified as an "S3 path" when it is prefixed with the S3 protocol: `s3://`.
+A path is identified as an "S3 path" when it is prefixed with the S3 protocol:
+`s3://`.
 
-For example `s3://bucket/path/to/folder` references a path `path/to/folder` inside
-of a bucket `bucket`.
+For example `s3://bucket/path/to/folder` references a path `path/to/folder`
+inside of a bucket `bucket`.
 
-S3 paths make use of the [s3](backup_restore.md#s3) config for authorization against
-the included bucket. Alternatively, the common environment variables recognized
-by the `aws` CLI (i.e. `AWS_PROFILE`, `AWS_REGION`, `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`,
-etc) will be automatically read.
+S3 paths make use of the [s3](backup_restore.md#s3) config for authorization
+against the included bucket. Alternatively, the common environment variables
+recognized by the `aws` CLI (i.e. `AWS_PROFILE`, `AWS_REGION`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, etc) will be automatically read.
 
 ## `strategy`
 
@@ -109,9 +110,9 @@ This option is **only** read during `restore` commands and has two valid values:
 `use_latest_filename` and `use_latest_metadata`.
 
 The restore-time "strategy" defines how databudgie should determine which file,
-on a per-table basis to read from. Note that each time you run `databudgie backup`,
-it's never altering preexisting files, instead it's writing new files to disk with
-a timestamp in the name to disambiguate.
+on a per-table basis to read from. Note that each time you run
+`databudgie backup`, it's never altering preexisting files, instead it's writing
+new files to disk with a timestamp in the name to disambiguate.
 
 - `use_latest_filename` will make use of the default file naming scheme which
   includes write-time timestamps in the name of the file, and chooses the most
@@ -138,20 +139,20 @@ relationships may encounter issues with this option (on those tables).
 
 Defaults to `select * from {table}`
 
-Specify the query to be used on a given match. The default, which simply selects the
-whole table is the most obviously useful query one might use, to backup the whole
-table.
+Specify the query to be used on a given match. The default, which simply selects
+the whole table is the most obviously useful query one might use, to backup the
+whole table.
 
 There aren't any constraints on the query to be executed, however, so this field
-can apply filters, perform joins, alter/obfuscate the data, or otherwise do whatever
-it wants.
+can apply filters, perform joins, alter/obfuscate the data, or otherwise do
+whatever it wants.
 
 ## `compression`
 
 Defaults to `null`.
 
-Depending on the size of tables, the backups can get quite large. By default compression
-is disabled, but it can be enabled for any/all table "data" backups.
+Depending on the size of tables, the backups can get quite large. By default
+compression is disabled, but it can be enabled for any/all table "data" backups.
 
 Valid values include: `gzip`.
 
@@ -165,8 +166,8 @@ restore side agree on the value of the `compression` key.
 
 Defaults to `[]`.
 
-This is most commonly useful when using globs, particularly when running up against
-the limitations of glob matching versus regex
+This is most commonly useful when using globs, particularly when running up
+against the limitations of glob matching versus regex
 
 ```yaml
 tables:
@@ -176,17 +177,18 @@ tables:
       - "tree_log"
 ```
 
-Note that `exclude` list entries can also be globs themselves. So you can use them
-to arrive at more complex matching criteria than could be achieved with the single
-`name` matching glob.
+Note that `exclude` list entries can also be globs themselves. So you can use
+them to arrive at more complex matching criteria than could be achieved with the
+single `name` matching glob.
 
 ## `follow_foreign_keys`
 
 Defaults to `false`.
 
-When `true`, any foreign keys on the table will be recursively followed when performing the
-backup/restore. This allows one to specify **only** the table one seeks to backup/restore
-and any tables related through foreign keys will also be backed up.
+When `true`, any foreign keys on the table will be recursively followed when
+performing the backup/restore. This allows one to specify **only** the table one
+seeks to backup/restore and any tables related through foreign keys will also be
+backed up.
 
 ```{note}
 The backup file that is stored/read from will be relative to the explicit table
@@ -202,3 +204,14 @@ on the restore-side due to foreign key constraints). For a given heirarchy of fo
 should remain constant, but doesnt preclude some future table/foreign key from taking
 control of that table by virtue of being higher up in the heirarchy.
 ```
+
+## `skip_if_exists`
+
+```{note}
+Unlike most options, this option only has an effect in the backup-side of the config.
+```
+
+Defaults to `false`.
+
+When `true`, skips the backing up the table, if there already exists backup data
+for the annotated table.

--- a/src/databudgie/backup.py
+++ b/src/databudgie/backup.py
@@ -230,13 +230,19 @@ def backup(
         storage: the storage backend to use for backing up the data.
         console: Console used for output
     """
+    path = table_op.location()
+
+    if table_op.raw_conf.skip_if_exists and storage.path_exists(path):
+        console.trace(f"Skipping {table_op.full_name} due to `skip_if_exists`")
+        return
+
     buffer = adapter.export_query(table_op.query())
 
     # path.join will handle optionally trailing slashes in the location
     compression = table_op.raw_conf.compression
 
     filename = storage.write_buffer(
-        table_op.location(), buffer, file_type=FileTypes.data, name=table_op.full_name, compression=compression
+        path, buffer, file_type=FileTypes.data, name=table_op.full_name, compression=compression
     )
 
     console.trace(f"Uploaded {table_op.full_name} to {filename}")

--- a/src/databudgie/config.py
+++ b/src/databudgie/config.py
@@ -246,6 +246,7 @@ class BackupTableConfig(Config):
     data: bool = True
     follow_foreign_keys: bool = False
     strict: bool = False
+    skip_if_exists: bool = False
 
     @classmethod
     def from_stack(cls, stack: ConfigStack, root_location: str | None = None):
@@ -267,6 +268,7 @@ class BackupTableConfig(Config):
             ddl=bool(ddl),
             follow_foreign_keys=bool(stack.get("follow_foreign_keys", False)),
             strict=bool(stack.get("strict", False)),
+            skip_if_exists=bool(stack.get("skip_if_exists", False)),
         )
 
 

--- a/src/databudgie/storage.py
+++ b/src/databudgie/storage.py
@@ -52,9 +52,11 @@ class LocalStorage:
         with open(path, "wb") as f:
             f.write(buffer.getbuffer())
 
-    def path_exists(self, path: str):
-        matching_objects = [dir_entry for dir_entry in os.scandir(path) if dir_entry.is_file()]
-        return len(matching_objects) >= 1
+    def path_exists(self, path: str) -> bool:
+        if not os.path.exists("path"):
+            return False
+
+        return any(dir_entry for dir_entry in os.scandir(path) if dir_entry.is_file())
 
     def get_file_content(
         self, path: str, selection_strategy: SelectionStrategy, file_type: FileTypes, compression: str | None = None
@@ -99,7 +101,7 @@ class S3Storage:
         s3_bucket: Bucket = self.resource.Bucket(s3_location.bucket)
         s3_bucket.put_object(Key=s3_location.key, Body=buffer)
 
-    def path_exists(self, path: str):
+    def path_exists(self, path: str) -> bool:
         s3_location = S3Location(path)
         s3_bucket: Bucket = self.resource.Bucket(s3_location.bucket)
         matching_objects = list(s3_bucket.objects.filter(Prefix=s3_location.key).all())

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -5,6 +5,7 @@ import tempfile
 from typing import Any, Dict, List
 from unittest.mock import patch
 
+import faker
 import pytest
 
 from databudgie.backup import backup_all
@@ -12,6 +13,8 @@ from databudgie.config import RootConfig
 from databudgie.s3 import is_s3_path, S3Location
 from tests.mockmodels.models import Customer
 from tests.utils import s3_config
+
+fake = faker.Faker()
 
 
 def test_backup_all(pg, s3_resource):

--- a/tests/test_skip_if_exists.py
+++ b/tests/test_skip_if_exists.py
@@ -1,0 +1,75 @@
+import pathlib
+import tempfile
+from dataclasses import replace
+
+import faker
+
+from databudgie.backup import backup_all
+from databudgie.config import RootConfig
+from tests.utils import mock_csv, mock_s3_csv, s3_config
+
+fake = faker.Faker()
+
+
+def test_skip_if_exists_in_s3(pg, s3_resource):
+    """Validate the `skip_if_exists` backup option skips tables with existing backups."""
+    path = "public.store"
+    file = f"{path}/2021-04-26T09:00:00.csv"
+
+    mock_store = {"id": 1, "name": fake.name()}
+    mock_s3_csv(s3_resource, file, [mock_store])
+
+    config = RootConfig.from_dict(
+        {
+            "location": "s3://sample-bucket/{table}",
+            "tables": ["public.store"],
+            "sequences": False,
+            "strict": True,
+            "skip_if_exists": True,
+            **s3_config,
+        }
+    )
+
+    existing_etag = s3_resource.Object("sample-bucket", file).e_tag
+
+    backup_all(pg, config.backup)
+
+    skipped_etag = s3_resource.Object("sample-bucket", file).e_tag
+    assert existing_etag == skipped_etag
+
+    config.backup.tables[0] = replace(config.backup.tables[0], skip_if_exists=False)
+    backup_all(pg, config.backup)
+
+    not_skipped_etag = s3_resource.Object("sample-bucket", file).e_tag
+    assert existing_etag != not_skipped_etag
+
+
+def test_skip_if_exists_in_local_file(pg, s3_resource):
+    """Validate the `skip_if_exists` backup option skips tables with existing backups."""
+    mock_store = {"id": 1, "name": fake.name()}
+    fake_file_data = mock_csv([mock_store]).read()
+
+    with tempfile.TemporaryDirectory() as dir_name:
+        path = pathlib.Path(dir_name, "2021-04-26T09:00:00.csv.csv")
+        path.write_bytes(fake_file_data)
+
+        config = RootConfig.from_dict(
+            {
+                "location": f"{dir_name}/{{table}}",
+                "tables": ["public.store"],
+                "sequences": False,
+                "strict": True,
+                "skip_if_exists": True,
+            }
+        )
+
+        backup_all(pg, config.backup)
+
+        skipped_bytes = path.read_bytes()
+        assert fake_file_data == skipped_bytes
+
+        config.backup.tables[0] = replace(config.backup.tables[0], skip_if_exists=False)
+        backup_all(pg, config.backup)
+
+        not_skipped_bytes = path.read_bytes()
+        assert fake_file_data == not_skipped_bytes


### PR DESCRIPTION
Adds a `skip_if_exists` flag to per-table backup config. Fixes https://github.com/schireson/databudgie/issues/45