### PR TITLE
feat: Route --conn through config so that config-level "connection:" …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databudgie"
-version = "2.8.1"
+version = "2.8.2"
 packages = [
     { include = "databudgie", from = "src" },
 ]

--- a/src/databudgie/cli/base.py
+++ b/src/databudgie/cli/base.py
@@ -1,4 +1,6 @@
-from typing import Callable, Optional, Union
+from __future__ import annotations
+
+from typing import Callable
 
 import click
 import sqlalchemy
@@ -6,7 +8,7 @@ import sqlalchemy.engine.url
 import sqlalchemy.orm
 import strapp.click
 
-from databudgie.config import BackupConfig, RestoreConfig, RootConfig
+from databudgie.config import BackupConfig, Connection, RestoreConfig, RootConfig
 from databudgie.output import Console
 
 version = getattr(sqlalchemy, "__version__", "")
@@ -19,17 +21,22 @@ else:
     create_url = sqlalchemy.engine.url.URL
 
 
-def _create_postgres_session(config: Union[BackupConfig, RestoreConfig], connection_name: Optional[str] = None):
-    if connection_name:
-        connection = config.connections.get(connection_name)
-        if connection is None:
-            raise click.UsageError(f"Connection '{connection_name}' not found")
-    else:
-        connection = config.connection
-        if connection is None:
-            raise click.UsageError("No config found for 'url' field. Either a 'connection' or a 'url' is required")
+def _create_postgres_session(config: BackupConfig | RestoreConfig):
+    connection: str | Connection = config.connection
+    if isinstance(config.connection, str):
+        if config.connection in config.connections:
+            # `connection` can either be a connection's name, or a literal connection string. We need
+            # to only overwrite the `connection` value if there is a correspondingly named connection
+            connection = config.connections[config.connection]
+        else:
+            raise click.UsageError(
+                f"'{config.connection}' did not resolve to a connection. 'url' or 'connection' must "
+                "resolve to a named connection or connection details."
+            )
 
+    assert isinstance(connection, Connection)
     url = connection.url
+
     if isinstance(url, dict):
         url_obj = create_url(**url)
     else:
@@ -51,18 +58,18 @@ def restore_config(root_config: RootConfig, console: Console):
     return root_config.restore
 
 
-def backup_db(backup_config: BackupConfig, connection_name: Optional[str] = None):
-    return _create_postgres_session(backup_config, connection_name)
+def backup_db(backup_config: BackupConfig):
+    return _create_postgres_session(backup_config)
 
 
-def restore_db(restore_config: RestoreConfig, connection_name: Optional[str] = None):
-    return _create_postgres_session(restore_config, connection_name)
+def restore_db(restore_config: RestoreConfig):
+    return _create_postgres_session(restore_config)
 
 
 def backup_manifest(backup_config: BackupConfig, backup_db):
     from databudgie.manifest.manager import BackupManifest
 
-    table_name: Optional[str] = backup_config.manifest
+    table_name: str | None = backup_config.manifest
     if table_name:
         return BackupManifest(backup_db, table_name)
     return None
@@ -71,7 +78,7 @@ def backup_manifest(backup_config: BackupConfig, backup_db):
 def restore_manifest(restore_config: RestoreConfig, restore_db):
     from databudgie.manifest.manager import RestoreManifest
 
-    table_name: Optional[str] = restore_config.manifest
+    table_name: str | None = restore_config.manifest
     if table_name:
         return RestoreManifest(restore_db, table_name)
     return None

--- a/src/databudgie/cli/commands.py
+++ b/src/databudgie/cli/commands.py
@@ -115,6 +115,7 @@ def cli(
         location=location,
         adapter=adapter,
         strict=strict,
+        connection=conn,
     )
 
     try:
@@ -131,7 +132,6 @@ def cli(
         root_config=root_config,
         verbosity=verbose,
         console=Console(verbosity=verbose),
-        connection_name=conn,
         dry_run=bool(dry_run),
         stats=stats if stats is not None else dry_run,
     )

--- a/src/databudgie/cli/config.py
+++ b/src/databudgie/cli/config.py
@@ -41,6 +41,7 @@ class CliConfig(DatabudgieConfig):
     location: str | None = None
     adapter: str | None = None
     strict: bool | None = None
+    connection: str | None = None
 
     def to_dict(self) -> dict:
         config = asdict(self)

--- a/tests/cli/test_base.py
+++ b/tests/cli/test_base.py
@@ -1,3 +1,5 @@
+import click
+import pytest
 from pytest_mock_resources import create_postgres_fixture
 from sqlalchemy import text
 
@@ -29,3 +31,25 @@ def test_create_postgres_session_url_components(pg_engine):
     config = BackupConfig.from_stack(ConfigStack({"url": url_parts}))
     session = _create_postgres_session(config)
     session.execute(text("select 1"))
+
+
+def test_connection_selection(pg_engine):
+    url = pg_engine.pmr_credentials.as_sqlalchemy_url()
+
+    try:
+        url_str = url.render_as_string(hide_password=False)
+    except AttributeError:
+        url_str = str(url)
+
+    assert url_str.startswith("postgresql+psycopg2://")
+    config = BackupConfig.from_stack(ConfigStack({"connections": {"foo": url_str}, "connection": "foo"}))
+
+    session = _create_postgres_session(config)
+    session.execute(text("select 1"))
+
+
+def test_missing_connection():
+    config = BackupConfig.from_stack(ConfigStack({"connections": {}, "connection": "foo"}))
+
+    with pytest.raises(click.UsageError):
+        _create_postgres_session(config)

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -28,7 +28,7 @@ def run_command(command, assert_exit_code=0):
 @pytest.mark.parametrize("command", ("backup", "restore"))
 def test_no_default_file_warns_of_no_url(command):
     result = run_command(command, assert_exit_code=2)
-    assert "No config found for 'url' field" in result.output
+    assert "did not resolve to a connection" in result.output
 
 
 class TestConfigCommand:
@@ -43,7 +43,7 @@ class TestConfigCommand:
 
         for part in ["backup", "restore"]:
             config_part = config[part]
-            assert config_part["connection"] == {"name": "default", "url": "foo"}
+            assert config_part["connection"] == "foo"
             assert config_part["ddl"]["enabled"] is True
             assert config_part["tables"][0]["location"] == "bar"
             assert config_part["tables"][0]["name"] == "baz"


### PR DESCRIPTION
…field works in the same way.

Additionally coerces the lack of a `connection:` value (either explicitly given or cli-given) as the "default" `connections` connection.

Fixes https://github.com/schireson/databudgie/issues/97