### PR TITLE
feat: Allow unnamed tables.

### DIFF
--- a/docs/source/config/table.md
+++ b/docs/source/config/table.md
@@ -47,6 +47,21 @@ tables:
   - '*.*'
 ```
 
+````{note}
+`name` **can** also be omitted entirely, with some caveats. The "name" field
+populates the `{table}` templated into queries and location paths (**both**
+of which default to including the `{table}` template value).
+
+Thus, if you omit the "name" field, you must have also provided a concrete "query"
+and "location" field.
+
+```yaml
+tables:
+  - query: select * from for_example_a_view
+    location: backups/public.for_example_a_view
+```
+````
+
 ### Globbing
 
 Using common globbing rules:

--- a/src/databudgie/adapter/base.py
+++ b/src/databudgie/adapter/base.py
@@ -173,6 +173,9 @@ class Adapter:
         tables = set()
         dependent_table_ops = []
         for table_op in table_ops:
+            if table_op.full_name is None:
+                continue
+
             tables.add(table_op.full_name)
 
             if not table_op.raw_conf.follow_foreign_keys:

--- a/src/databudgie/config.py
+++ b/src/databudgie/config.py
@@ -236,7 +236,7 @@ class Connection(Config):
 
 @dataclass
 class BackupTableConfig(Config):
-    name: str
+    name: str | None = None
     location: str = "backups/{table}"
     query: str = "select * from {table}"
     compression: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import logging
+
 import boto3
 import pytest
 from freezegun import freeze_time
@@ -6,6 +8,8 @@ from pytest_mock_resources import create_postgres_fixture, PostgresConfig
 
 from databudgie.config import RootConfig
 from tests.mockmodels.models import Base
+
+logging.basicConfig(level="INFO")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -177,6 +177,26 @@ def test_backup_failure(pg):
             assert console.call_count == 2
 
 
+def test_backup_unnamed_table(pg, mf, s3_resource):
+    """Validate unnamed table can be backed up."""
+    customer = mf.customer.new(external_id="cid_123")
+
+    config = RootConfig.from_dict(
+        {
+            "backup": {
+                "location": "s3://sample-bucket/databudgie/test/{table}",
+                "tables": [{"query": "select * from public.customer"}],
+                **s3_config,
+            },
+        }
+    )
+    backup_all(pg, config.backup)
+
+    _validate_backup_contents(
+        get_file_buffer("s3://sample/databudgie/test/None/2021-04-26T09:00:00.csv", s3_resource), [customer]
+    )
+
+
 def _validate_backup_contents(buffer, expected_contents: List[Customer]):
     """Validate the contents of a backup file. Columns from the file will be raw."""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import List
 
+from botocore.exceptions import ClientError
 from mypy_boto3_s3.service_resource import S3ServiceResource
 
 from databudgie.s3 import is_s3_path, S3Location
@@ -49,7 +50,13 @@ def get_file_buffer(filename, s3_resource=None):
         assert s3_resource
         location = S3Location(filename)
         uploaded_object = s3_resource.Object("sample-bucket", location.key)
-        uploaded_object.download_fileobj(buffer)
+
+        try:
+            uploaded_object.download_fileobj(buffer)
+        except ClientError:
+            log.info(str(list(s3_resource.Bucket("sample-bucket").objects.all())))
+
+            raise
     else:
         try:
             with open(filename, "rb") as f:


### PR DESCRIPTION
Entries without names act as backup-only "tables", which are excluded from typical expansion through globs or other mechanisms (foreign key following).